### PR TITLE
bank: use datastore cleaner for consistency in tests

### DIFF
--- a/src/test/java/com/clouway/persistent/DatastoreCleaner.java
+++ b/src/test/java/com/clouway/persistent/DatastoreCleaner.java
@@ -1,0 +1,24 @@
+package com.clouway.persistent;
+
+import com.clouway.persistent.adapter.jdbc.ConnectionProvider;
+import com.clouway.persistent.datastore.DataStore;
+
+/**
+ * @author Miroslav Genov (miroslav.genov@clouway.com)
+ */
+public class DatastoreCleaner {
+
+  private final ConnectionProvider provider = new ConnectionProvider();
+  private final DataStore dataStore = new DataStore(provider);
+  private final String[] table;
+
+  public DatastoreCleaner(String... table) {
+    this.table = table;
+  }
+
+  public void perform() {
+    for (String each : table) {
+      dataStore.update("truncate " + each);
+    }
+  }
+}

--- a/src/test/java/com/clouway/persistent/adapter/jdbc/PersistentAccountRepositoryTest.java
+++ b/src/test/java/com/clouway/persistent/adapter/jdbc/PersistentAccountRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.clouway.persistent.adapter.jdbc;
 
+import com.clouway.persistent.DatastoreCleaner;
 import com.clouway.core.Account;
 import com.clouway.persistent.datastore.DataStore;
 import org.junit.Before;
@@ -19,10 +20,9 @@ public class PersistentAccountRepositoryTest {
 
   @Before
   public void setUp() throws Exception {
-    ConnectionProvider provider = new ConnectionProvider();
-    DataStore dataStore = new DataStore(provider);
-    repo = new PersistentAccountRepository(dataStore);
-    dataStore.update("truncate accounts");
+    repo = new PersistentAccountRepository(new DataStore(new ConnectionProvider()));
+    DatastoreCleaner datastoreCleaner = new DatastoreCleaner("accounts");
+    datastoreCleaner.perform();
   }
 
   @Test


### PR DESCRIPTION
Extracted a DatastoreCleaner class which acts as Helper for tests for cleaning of the existing table entries.