### PR TITLE
bank: change misleading name of index page to registration page

### DIFF
--- a/src/main/java/com/clouway/http/servlets/LoginPageServlet.java
+++ b/src/main/java/com/clouway/http/servlets/LoginPageServlet.java
@@ -38,7 +38,7 @@ public class LoginPageServlet extends HttpServlet {
 
   @Override
   protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-    servletResponseWriter.renderPage("login.html", Collections.emptyMap(), resp);
+    servletResponseWriter.renderPage("login.html", Collections.singletonMap("error", ""), resp);
   }
 
   @Override

--- a/src/main/java/com/clouway/http/servlets/RegistrationPageServlet.java
+++ b/src/main/java/com/clouway/http/servlets/RegistrationPageServlet.java
@@ -19,25 +19,25 @@ import java.util.Collections;
 /**
  * @author Martin Milev <martinmariusmilev@gmail.com>
  */
-public class IndexPageServlet extends HttpServlet {
+public class RegistrationPageServlet extends HttpServlet {
   private AccountRepository repository;
   private ServletPageRenderer servletResponseWriter;
 
   @Ignore
   @SuppressWarnings("unused")
-  public IndexPageServlet() {
+  public RegistrationPageServlet() {
     this(new PersistentAccountRepository(new DataStore(new ConnectionProvider())), new HtmlServletPageRenderer());
   }
 
   @VisibleForTesting
-  public IndexPageServlet(AccountRepository repository, ServletPageRenderer servletResponseWriter) {
+  public RegistrationPageServlet(AccountRepository repository, ServletPageRenderer servletResponseWriter) {
     this.repository = repository;
     this.servletResponseWriter = servletResponseWriter;
   }
 
   @Override
   protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-    servletResponseWriter.renderPage("index.html", Collections.emptyMap(), resp);
+    servletResponseWriter.renderPage("register.html", Collections.singletonMap("error", ""), resp);
   }
 
   @Override
@@ -52,7 +52,7 @@ public class IndexPageServlet extends HttpServlet {
 
       resp.sendRedirect("/login");
     } else {
-      servletResponseWriter.renderPage("index.html", Collections.singletonMap("error", "Username is taken"), resp);
+      servletResponseWriter.renderPage("register.html", Collections.singletonMap("error", "Username is taken"), resp);
     }
   }
 }

--- a/src/main/resources/com/clouway/http/servlets/register.html
+++ b/src/main/resources/com/clouway/http/servlets/register.html
@@ -17,7 +17,7 @@
         </ul>
     </nav>
 
-    <form class="form-horizontal" action="/" method='post'>
+    <form class="form-horizontal" action="/register" method='post'>
         <div class="form-group">
             <p class="text-danger">${error}</p>
             <input class="form-control" name="name" type="text" pattern="[A-Za-z]{1,30}" placeholder="Name"

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -7,18 +7,20 @@
 <web-app>
 
   <servlet>
-    <servlet-name>index</servlet-name>
-    <servlet-class>com.clouway.http.servlets.IndexPageServlet</servlet-class>
+    <servlet-name>registrationPageServlet</servlet-name>
+    <servlet-class>com.clouway.http.servlets.RegistrationPageServlet</servlet-class>
   </servlet>
+
   <servlet>
     <servlet-name>login</servlet-name>
     <servlet-class>com.clouway.http.servlets.LoginPageServlet</servlet-class>
   </servlet>
 
   <servlet-mapping>
-    <servlet-name>index</servlet-name>
-    <url-pattern>/</url-pattern>
+    <servlet-name>registrationPageServlet</servlet-name>
+    <url-pattern>/register</url-pattern>
   </servlet-mapping>
+
   <servlet-mapping>
     <servlet-name>login</servlet-name>
     <url-pattern>/login</url-pattern>

--- a/src/test/java/com/clouway/http/servlets/LoginPageServletTest.java
+++ b/src/test/java/com/clouway/http/servlets/LoginPageServletTest.java
@@ -40,7 +40,7 @@ public class LoginPageServletTest {
     FakeHttpServletResponse response = createResponse();
 
     context.checking(new Expectations() {{
-      oneOf(servletResponseWriter).renderPage("login.html", Collections.emptyMap(), response);
+      oneOf(servletResponseWriter).renderPage("login.html", Collections.singletonMap("error", ""), response);
     }});
 
     servlet.doGet(request, response);

--- a/src/test/java/com/clouway/http/servlets/RegistrationPageServletTest.java
+++ b/src/test/java/com/clouway/http/servlets/RegistrationPageServletTest.java
@@ -22,7 +22,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 /**
  * @author Martin Milev <martinmariusmilev@gmail.com>
  */
-public class IndexPageServletTest {
+public class RegistrationPageServletTest {
 
   @Rule
   public JUnitRuleMockery context = new JUnitRuleMockery();
@@ -30,7 +30,7 @@ public class IndexPageServletTest {
   private FakeHttpServletRequest request = new FakeHttpServletRequest();
   private FakeHttpServletResponse response = new FakeHttpServletResponse();
   private ByteArrayOutputStream stream;
-  private IndexPageServlet servlet;
+  private RegistrationPageServlet servlet;
   private PrintWriter writer;
 
   private AccountRepository repo = context.mock(AccountRepository.class);
@@ -38,7 +38,7 @@ public class IndexPageServletTest {
 
   @Before
   public void setUp() throws Exception {
-    servlet = new IndexPageServlet(repo, servletResponseWriter);
+    servlet = new RegistrationPageServlet(repo, servletResponseWriter);
     stream = new ByteArrayOutputStream();
     writer = new PrintWriter(stream);
   }
@@ -48,7 +48,7 @@ public class IndexPageServletTest {
     response.setWriter(writer);
 
     context.checking(new Expectations() {{
-      oneOf(servletResponseWriter).renderPage("index.html", Collections.emptyMap(), response);
+      oneOf(servletResponseWriter).renderPage("register.html", Collections.singletonMap("error", ""), response);
     }});
 
     servlet.doGet(request, response);
@@ -63,7 +63,7 @@ public class IndexPageServletTest {
       oneOf(repo).getByName("John");
       will(returnValue(Optional.of(new Account("John", "pwd", 0))));
 
-      oneOf(servletResponseWriter).renderPage("index.html", Collections.singletonMap("error", "Username is taken"), response);
+      oneOf(servletResponseWriter).renderPage("register.html", Collections.singletonMap("error", "Username is taken"), response);
     }});
 
     servlet.doPost(request, response);


### PR DESCRIPTION
The misleading name of Index page is now changed to Registration page which is and the role of the page.

The app no longer serves "/" as expected, but with the integration with security it will be handled as follow:

User tries to open "/" and if it's not authenticated he will be redirected to the login page for login.

If he is authenticated then a proper home page should be rendered on the screen.