### PR TITLE
bank: continious integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: java
+jdk:
+  - oraclejdk8
+  - oraclejdk7
+services:
+  - mysql
+before_script:
+  - mysql -e 'create database bank_testdb;'
+  - mysql -u travis -db bank_testdb < schemas/Account_dll.sql
+after_script:
+  - mysql -e 'drop database bank_testdb;'


### PR DESCRIPTION
Added .travis.yml and database.yml so that we could use travis-ci. That way our build process will be authenticated by the CI server, thus ensuring we aren't breaking the build.

Fixes #100