### PR TITLE
bank: validation for username and password

### DIFF
--- a/src/main/java/com/clouway/core/Validator.java
+++ b/src/main/java/com/clouway/core/Validator.java
@@ -1,0 +1,40 @@
+package com.clouway.core;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author Borislav Gadjev <gadjevb@gmail.com>
+ */
+public class Validator {
+
+  public Boolean validateName(String sequence) {
+    Boolean valid = false;
+    Pattern pattern = Pattern.compile("\\w{6,50}");
+    Matcher matcher = pattern.matcher(sequence);
+
+    if (matcher.find()) {
+      String validSequence = matcher.group();
+      if (validSequence.equals(sequence)) {
+        valid = true;
+      }
+    }
+
+    return valid;
+  }
+
+  public Boolean validatePassword(String sequence) {
+    Boolean valid = false;
+    Pattern pattern = Pattern.compile("\\w{6,18}");
+    Matcher matcher = pattern.matcher(sequence);
+
+    if (matcher.find()) {
+      String validSequence = matcher.group();
+      if (validSequence.equals(sequence)) {
+        valid = true;
+      }
+    }
+
+    return valid;
+  }
+}

--- a/src/main/java/com/clouway/http/servlets/LoginPageServlet.java
+++ b/src/main/java/com/clouway/http/servlets/LoginPageServlet.java
@@ -3,6 +3,7 @@ package com.clouway.http.servlets;
 import com.clouway.core.Account;
 import com.clouway.core.AccountRepository;
 import com.clouway.core.ServletPageRenderer;
+import com.clouway.core.Validator;
 import com.clouway.persistent.adapter.jdbc.ConnectionProvider;
 import com.clouway.persistent.adapter.jdbc.PersistentAccountRepository;
 import com.clouway.persistent.datastore.DataStore;
@@ -45,6 +46,13 @@ public class LoginPageServlet extends HttpServlet {
   protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
     String name = req.getParameter("name");
     String pswd = req.getParameter("password");
+    Validator validator = new Validator();
+
+    if (!validator.validateName(name) || !validator.validatePassword(pswd)) {
+      servletResponseWriter.renderPage("login.html", Collections.singletonMap("error", "Wrong input"), resp);
+      return;
+    }
+
     Optional<Account> possibleAccount = repository.getByName(name);
 
     if (!possibleAccount.isPresent()) {

--- a/src/main/java/com/clouway/http/servlets/RegistrationPageServlet.java
+++ b/src/main/java/com/clouway/http/servlets/RegistrationPageServlet.java
@@ -3,6 +3,7 @@ package com.clouway.http.servlets;
 import com.clouway.core.Account;
 import com.clouway.core.AccountRepository;
 import com.clouway.core.ServletPageRenderer;
+import com.clouway.core.Validator;
 import com.clouway.persistent.adapter.jdbc.ConnectionProvider;
 import com.clouway.persistent.adapter.jdbc.PersistentAccountRepository;
 import com.clouway.persistent.datastore.DataStore;
@@ -43,9 +44,15 @@ public class RegistrationPageServlet extends HttpServlet {
   @Override
   protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
     String name = req.getParameter("name");
+    String password = req.getParameter("password");
+    Validator validator = new Validator();
+
+    if (!validator.validateName(name) || !validator.validatePassword(password)) {
+      servletResponseWriter.renderPage("register.html", Collections.singletonMap("error", "Wrong input"), resp);
+      return;
+    }
 
     if (!repository.getByName(name).isPresent()) {
-      String password = req.getParameter("password");
       Account account = new Account(name, password, 0);
 
       repository.register(account);

--- a/src/test/java/com/clouway/http/servlets/LoginPageServletTest.java
+++ b/src/test/java/com/clouway/http/servlets/LoginPageServletTest.java
@@ -50,15 +50,15 @@ public class LoginPageServletTest {
   public void login() throws Exception {
     FakeHttpServletRequest request = createRequest(
             ImmutableMap.of(
-                    "name", "John",
-                    "password", "pwd"
+                    "name", "Johnathan",
+                    "password", "password"
             )
     );
     FakeHttpServletResponse response = createResponse();
 
     context.checking(new Expectations() {{
-      oneOf(repo).getByName("John");
-      will(returnValue(Optional.of(new Account("John", "pwd", 0))));
+      oneOf(repo).getByName("Johnathan");
+      will(returnValue(Optional.of(new Account("Johnathan", "password", 0))));
 
     }});
 
@@ -70,14 +70,14 @@ public class LoginPageServletTest {
   public void wrongUsername() throws Exception {
     FakeHttpServletRequest request = createRequest(
             ImmutableMap.of(
-                    "name", "John",
-                    "password", "pwd"
+                    "name", "Johnathan",
+                    "password", "password"
             )
     );
     final HttpServletResponse response = createResponse();
 
     context.checking(new Expectations() {{
-      oneOf(repo).getByName("John");
+      oneOf(repo).getByName("Johnathan");
       will(returnValue(Optional.empty()));
 
       oneOf(servletResponseWriter).renderPage("login.html", Collections.singletonMap("error", "Wrong username"), response);
@@ -90,17 +90,34 @@ public class LoginPageServletTest {
   public void wrongPassword() throws Exception {
     FakeHttpServletRequest request = createRequest(
             ImmutableMap.of(
-                    "name", "John",
-                    "password", "pwd"
+                    "name", "Johnathan",
+                    "password", "wrongPassword"
             )
     );
     HttpServletResponse response = createResponse();
 
     context.checking(new Expectations() {{
-      oneOf(repo).getByName("John");
-      will(returnValue(Optional.of(new Account("John", "wrong", 0))));
+      oneOf(repo).getByName("Johnathan");
+      will(returnValue(Optional.of(new Account("Johnathan", "password", 0))));
 
       oneOf(servletResponseWriter).renderPage("login.html", Collections.singletonMap("error", "Wrong password"), response);
+    }});
+
+    servlet.doPost(request, response);
+  }
+
+  @Test
+  public void wrongInput() throws Exception {
+    FakeHttpServletRequest request = createRequest(
+            ImmutableMap.of(
+                    "name", "John",
+                    "password", "wrong"
+            )
+    );
+    HttpServletResponse response = createResponse();
+
+    context.checking(new Expectations() {{
+      oneOf(servletResponseWriter).renderPage("login.html", Collections.singletonMap("error", "Wrong input"), response);
     }});
 
     servlet.doPost(request, response);

--- a/src/test/java/com/clouway/http/servlets/RegistrationPageServletTest.java
+++ b/src/test/java/com/clouway/http/servlets/RegistrationPageServletTest.java
@@ -56,12 +56,13 @@ public class RegistrationPageServletTest {
 
   @Test
   public void takenUsername() throws Exception {
-    request.setParameter("name", "John");
+    request.setParameter("name", "Johnathan");
+    request.setParameter("password", "password");
     response.setWriter(writer);
 
     context.checking(new Expectations() {{
-      oneOf(repo).getByName("John");
-      will(returnValue(Optional.of(new Account("John", "pwd", 0))));
+      oneOf(repo).getByName("Johnathan");
+      will(returnValue(Optional.of(new Account("Johnathan", "password", 0))));
 
       oneOf(servletResponseWriter).renderPage("register.html", Collections.singletonMap("error", "Username is taken"), response);
     }});
@@ -70,15 +71,28 @@ public class RegistrationPageServletTest {
   }
 
   @Test
-  public void register() throws Exception {
+  public void wrongInput() throws Exception {
     request.setParameter("name", "John");
-    request.setParameter("password", "Johny");
+    request.setParameter("password","password");
     response.setWriter(writer);
 
     context.checking(new Expectations() {{
-      oneOf(repo).getByName("John");
+      oneOf(servletResponseWriter).renderPage("register.html", Collections.singletonMap("error", "Wrong input"), response);
+    }});
+
+    servlet.doPost(request, response);
+  }
+
+  @Test
+  public void register() throws Exception {
+    request.setParameter("name", "Johnathan");
+    request.setParameter("password", "password");
+    response.setWriter(writer);
+
+    context.checking(new Expectations() {{
+      oneOf(repo).getByName("Johnathan");
       will(returnValue(Optional.empty()));
-      oneOf(repo).register(new Account("John", "Johny", 0));
+      oneOf(repo).register(new Account("Johnathan", "password", 0));
     }});
 
     servlet.doPost(request, response);


### PR DESCRIPTION
Added a basic validation for username and password. For a username to be valid, it must contain a-zA-Z0-9 with length between 6 - 50 character. For a password to be valid, it must contain a-zA-Z0-9 with length between 6 - 18 characters.

Fixes #74